### PR TITLE
Allow for yt-nocookie playlists

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -33,13 +33,13 @@
         },
         
         {
-            "matches": ["*://www.youtube-nocookie.com/embed/*"],
+            "matches": ["*://www.youtube-nocookie.com/embed*"],
             "js": ["src/pt-setup.js"],
             "run_at": "document_start",
             "all_frames": true
         },
         {
-            "matches": ["*://www.youtube-nocookie.com/embed/*"],
+            "matches": ["*://www.youtube-nocookie.com/embed*"],
             "js": ["src/pt-main.js"],
             "all_frames": true
         },


### PR DESCRIPTION
Match embedded videos that are in a playlist, i.e.

`/embed?v=VIDEOID&list=PLAYLISTID&index=INDEX`

for youtube-nocookie.com


The general youtube.com match at the top already covers this for youtube.com/embed